### PR TITLE
Implement Passing Data with Context #154

### DIFF
--- a/react-advanced/src/App.js
+++ b/react-advanced/src/App.js
@@ -11,6 +11,7 @@ import { InputText } from "./useState/preserving-resetting/inputText";
 import { SwapField } from "./useState/preserving-resetting/swapField";
 import { ContactManager } from "./useState/preserving-resetting/detailForm";
 import { ContactList } from "./useState/preserving-resetting/contactList";
+import { ImageList } from "./useContext/imageList";
 
 const App = () => {
   return (
@@ -30,6 +31,9 @@ const App = () => {
             <Link to="/preservingAndResettingState">
               Preserving And Resetting State
             </Link>
+          </li>
+          <li>
+            <Link to="/passingDataWithContext">Passing Data With Context</Link>
           </li>
         </ul>
       </nav>
@@ -68,6 +72,7 @@ const App = () => {
             </>
           }
         />
+        <Route path="/passingDataWithContext" element={<ImageList />} />
       </Routes>
     </Router>
   );

--- a/react-advanced/src/useContext/imageList.jsx
+++ b/react-advanced/src/useContext/imageList.jsx
@@ -1,0 +1,118 @@
+import { createContext, useContext, useState } from "react";
+
+export const ImageList = () => {
+  const [isLarge, setIsLarge] = useState(false);
+  const imageSize = isLarge ? 150 : 100;
+
+  const handleChange = (e) => {
+    setIsLarge(e.target.checked);
+  };
+
+  return (
+    <ImageSizeContext.Provider value={imageSize}>
+      <label>
+        <input
+          type="checkbox"
+          checked={isLarge}
+          onChange={handleChange}
+        />
+        Use large images
+      </label>
+      <hr />
+      <ListPlace imageSize={imageSize} />
+    </ImageSizeContext.Provider>
+  );
+};
+
+const ListPlace = () => {
+  const listItem = places.map((place) => (
+    <li key={place.id}>
+      <Place place={place} />
+    </li>
+  ));
+
+  return <ul>{listItem}</ul>;
+};
+
+const Place = ({ place }) => {
+  return (
+    <>
+      <PlaceImage place={place} />
+      <p>
+        <b>{place.name}</b>
+        {": " + place.description}
+      </p>
+    </>
+  );
+};
+
+const PlaceImage = ({ place }) => {
+  const imageSize = useContext(ImageSizeContext);
+
+  return (
+    <img
+      src={getImageUrl(place)}
+      alt={place.name}
+      width={imageSize}
+      height={imageSize}
+    />
+  );
+};
+
+const ImageSizeContext = createContext(500);
+
+const getImageUrl = (place) => {
+  return "https://i.imgur.com/" + place.imageId + "l.jpg";
+};
+
+const places = [
+  {
+    id: 0,
+    name: "Bo-Kaap in Cape Town, South Africa",
+    description:
+      "The tradition of choosing bright colors for houses began in the late 20th century.",
+    imageId: "K9HVAGH",
+  },
+  {
+    id: 1,
+    name: "Rainbow Village in Taichung, Taiwan",
+    description:
+      "To save the houses from demolition, Huang Yung-Fu, a local resident, painted all 1,200 of them in 1924.",
+    imageId: "9EAYZrt",
+  },
+  {
+    id: 2,
+    name: "Macromural de Pachuca, Mexico",
+    description:
+      "One of the largest murals in the world covering homes in a hillside neighborhood.",
+    imageId: "DgXHVwu",
+  },
+  {
+    id: 3,
+    name: "Selarón Staircase in Rio de Janeiro, Brazil",
+    description:
+      'This landmark was created by Jorge Selarón, a Chilean-born artist, as a "tribute to the Brazilian people."',
+    imageId: "aeO3rpI",
+  },
+  {
+    id: 4,
+    name: "Burano, Italy",
+    description:
+      "The houses are painted following a specific color system dating back to 16th century.",
+    imageId: "kxsph5C",
+  },
+  {
+    id: 5,
+    name: "Chefchaouen, Marocco",
+    description:
+      "There are a few theories on why the houses are painted blue, including that the color repels mosquitos or that it symbolizes sky and heaven.",
+    imageId: "rTqKo46",
+  },
+  {
+    id: 6,
+    name: "Gamcheon Culture Village in Busan, South Korea",
+    description:
+      "In 2009, the village was converted into a cultural hub by painting the houses and featuring exhibitions and art installations.",
+    imageId: "ZfQOOzf",
+  },
+];


### PR DESCRIPTION
In this section, I learned how to pass data with useContext to avoid prop drilling.

1. What “prop drilling” is?

- Prop Drilling: 
  - When you need to pass data from a parent component to a deeper nested child component, but intermediate components don't actually need that data.
  - This results in passing props through intermediate components just to get the data where it's needed, making the code complex and harder to maintain.

2. How to replace repetitive prop passing with context?

- It's a way to pass data down to child components without the need to pass props at every level. 
- Context helps avoid prop drilling by providing a mechanism to access data directly from any component without passing props through intermediary components.

3. Common use cases for context?

- Theming: If your app lets the user change its appearance (e.g. dark mode).
- Current account: Many components might need to know the currently logged in user.