### PR TITLE
Implement combining reducer with context #176

### DIFF
--- a/react-advanced/src/App.js
+++ b/react-advanced/src/App.js
@@ -11,6 +11,7 @@ import { InputText } from "./useState/preserving-resetting/inputText";
 import { SwapField } from "./useState/preserving-resetting/swapField";
 import { ContactManager } from "./useState/preserving-resetting/detailForm";
 import { ContactList } from "./useState/preserving-resetting/contactList";
+import { TaskApp } from "./TaskApp";
 
 const App = () => {
   return (
@@ -29,6 +30,11 @@ const App = () => {
           <li>
             <Link to="/preservingAndResettingState">
               Preserving And Resetting State
+            </Link>
+          </li>
+          <li>
+            <Link to="/combiningReducerWithContext">
+              Combining Reducer with Context
             </Link>
           </li>
         </ul>
@@ -68,6 +74,7 @@ const App = () => {
             </>
           }
         />
+        <Route path="/combiningReducerWithContext" element={<TaskApp />} />
       </Routes>
     </Router>
   );

--- a/react-advanced/src/TaskApp/addTask.jsx
+++ b/react-advanced/src/TaskApp/addTask.jsx
@@ -1,0 +1,33 @@
+import { useContext, useState } from "react";
+import { TaskDispatchContext } from "./taskContext";
+
+export const AddTask = () => {
+  const [text, setText] = useState("");
+  const dispatch = useContext(TaskDispatchContext);
+
+  const handleChangeInput = (e) => {
+    setText(e.target.value);
+  };
+
+  const handleAddTask = () => {
+    setText("");
+    dispatch({
+      type: "added",
+      id: nextId++,
+      text: text,
+    });
+  };
+
+  return (
+    <>
+      <input
+        placeholder="Add task"
+        value={text}
+        onChange={handleChangeInput}
+      />
+      <button onClick={handleAddTask}>Add</button>
+    </>
+  );
+};
+
+let nextId = 3;

--- a/react-advanced/src/TaskApp/addTask.jsx
+++ b/react-advanced/src/TaskApp/addTask.jsx
@@ -1,9 +1,9 @@
-import { useContext, useState } from "react";
-import { TaskDispatchContext } from "./taskContext";
+import { useState } from "react";
+import { useTasksDispatch } from "./taskContext";
 
 export const AddTask = () => {
   const [text, setText] = useState("");
-  const dispatch = useContext(TaskDispatchContext);
+  const dispatch = useTasksDispatch();
 
   const handleChangeInput = (e) => {
     setText(e.target.value);

--- a/react-advanced/src/TaskApp/index.jsx
+++ b/react-advanced/src/TaskApp/index.jsx
@@ -1,56 +1,13 @@
-import { useReducer } from "react";
 import { AddTask } from "./addTask";
+import { TaskProvider } from "./taskContext";
 import { TaskList } from "./taskList";
-import { TaskContext, TaskDispatchContext } from "./taskContext";
 
 export const TaskApp = () => {
-  const [tasks, dispatch] = useReducer(tasksReducer, initialTasks);
-
   return (
-    <>
-      <TaskContext.Provider value={tasks}>
-        <TaskDispatchContext.Provider value={dispatch}>
-          <h1>Day off in Kyoto</h1>
-          <AddTask />
-          <TaskList />
-        </TaskDispatchContext.Provider>
-      </TaskContext.Provider>
-    </>
+    <TaskProvider>
+      <h1>Day off in Kyoto</h1>
+      <AddTask />
+      <TaskList />
+    </TaskProvider>
   );
 };
-
-const tasksReducer = (tasks, action) => {
-  switch (action.type) {
-    case "added": {
-      return [
-        ...tasks,
-        {
-          id: action.id,
-          text: action.text,
-          done: false,
-        },
-      ];
-    }
-    case "changed": {
-      return tasks.map((t) => {
-        if (t.id === action.task.id) {
-          return action.task;
-        } else {
-          return t;
-        }
-      });
-    }
-    case "deleted": {
-      return tasks.filter((t) => t.id !== action.id);
-    }
-    default: {
-      throw Error("Unknown action: " + action.type);
-    }
-  }
-};
-
-const initialTasks = [
-  { id: 0, text: "Philosopher’s Path", done: true },
-  { id: 1, text: "Visit the temple", done: false },
-  { id: 2, text: "Drink matcha", done: false },
-];

--- a/react-advanced/src/TaskApp/index.jsx
+++ b/react-advanced/src/TaskApp/index.jsx
@@ -1,0 +1,56 @@
+import { useReducer } from "react";
+import { AddTask } from "./addTask";
+import { TaskList } from "./taskList";
+import { TaskContext, TaskDispatchContext } from "./taskContext";
+
+export const TaskApp = () => {
+  const [tasks, dispatch] = useReducer(tasksReducer, initialTasks);
+
+  return (
+    <>
+      <TaskContext.Provider value={tasks}>
+        <TaskDispatchContext.Provider value={dispatch}>
+          <h1>Day off in Kyoto</h1>
+          <AddTask />
+          <TaskList />
+        </TaskDispatchContext.Provider>
+      </TaskContext.Provider>
+    </>
+  );
+};
+
+const tasksReducer = (tasks, action) => {
+  switch (action.type) {
+    case "added": {
+      return [
+        ...tasks,
+        {
+          id: action.id,
+          text: action.text,
+          done: false,
+        },
+      ];
+    }
+    case "changed": {
+      return tasks.map((t) => {
+        if (t.id === action.task.id) {
+          return action.task;
+        } else {
+          return t;
+        }
+      });
+    }
+    case "deleted": {
+      return tasks.filter((t) => t.id !== action.id);
+    }
+    default: {
+      throw Error("Unknown action: " + action.type);
+    }
+  }
+};
+
+const initialTasks = [
+  { id: 0, text: "Philosopher’s Path", done: true },
+  { id: 1, text: "Visit the temple", done: false },
+  { id: 2, text: "Drink matcha", done: false },
+];

--- a/react-advanced/src/TaskApp/taskContext.jsx
+++ b/react-advanced/src/TaskApp/taskContext.jsx
@@ -1,4 +1,61 @@
-import { createContext } from "react";
+import { createContext, useContext, useReducer } from "react";
 
-export const TaskContext = createContext(null)
-export const TaskDispatchContext = createContext(null)
+const TaskContext = createContext(null);
+
+const TaskDispatchContext = createContext(null);
+
+export const TaskProvider = ({ children }) => {
+  const [tasks, dispatch] = useReducer(tasksReducer, initialTasks);
+
+  return (
+    <TaskContext.Provider value={tasks}>
+      <TaskDispatchContext.Provider value={dispatch}>
+        {children}
+      </TaskDispatchContext.Provider>
+    </TaskContext.Provider>
+  );
+};
+
+export const useTasks = () => {
+  return useContext(TaskContext);
+};
+
+export const useTasksDispatch = () => {
+  return useContext(TaskDispatchContext);
+};
+
+const tasksReducer = (tasks, action) => {
+  switch (action.type) {
+    case "added": {
+      return [
+        ...tasks,
+        {
+          id: action.id,
+          text: action.text,
+          done: false,
+        },
+      ];
+    }
+    case "changed": {
+      return tasks.map((t) => {
+        if (t.id === action.task.id) {
+          return action.task;
+        } else {
+          return t;
+        }
+      });
+    }
+    case "deleted": {
+      return tasks.filter((t) => t.id !== action.id);
+    }
+    default: {
+      throw Error("Unknown action: " + action.type);
+    }
+  }
+};
+
+const initialTasks = [
+  { id: 0, text: "Philosopher’s Path", done: true },
+  { id: 1, text: "Visit the temple", done: false },
+  { id: 2, text: "Drink matcha", done: false },
+];

--- a/react-advanced/src/TaskApp/taskContext.jsx
+++ b/react-advanced/src/TaskApp/taskContext.jsx
@@ -1,0 +1,4 @@
+import { createContext } from "react";
+
+export const TaskContext = createContext(null)
+export const TaskDispatchContext = createContext(null)

--- a/react-advanced/src/TaskApp/taskList.jsx
+++ b/react-advanced/src/TaskApp/taskList.jsx
@@ -1,0 +1,87 @@
+import { useContext, useState } from "react";
+import { TaskContext, TaskDispatchContext } from "./taskContext";
+
+export const TaskList = () => {
+  const tasks = useContext(TaskContext);
+  return (
+    <ul>
+      {tasks.map((task) => (
+        <li key={task.id}>
+          <Task task={task} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const Task = ({ task }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const dispatch = useContext(TaskDispatchContext);
+  let taskContent;
+
+  const handleCloseEditing = () => {
+    setIsEditing(false);
+  };
+
+  const handleOpenEditing = () => {
+    setIsEditing(true);
+  };
+
+  const handleChangeTask = (e) => {
+    dispatch({
+      type: "changed",
+      task: {
+        ...task,
+        text: e.target.value,
+      },
+    });
+  };
+
+  const handleChangeCheckbox = (e) => {
+    dispatch({
+      type: "changed",
+      task: {
+        ...task,
+        done: e.target.checked,
+      },
+    });
+  };
+
+  const handleDeleteTask = () => {
+    dispatch({
+      type: "deleted",
+      id: task.id,
+    });
+  };
+
+  if (isEditing) {
+    taskContent = (
+      <>
+        <input
+          value={task.text}
+          onChange={handleChangeTask}
+        />
+        <button onClick={handleCloseEditing}>Save</button>
+      </>
+    );
+  } else {
+    taskContent = (
+      <>
+        {task.text}
+        <button onClick={handleOpenEditing}>Edit</button>
+      </>
+    );
+  }
+
+  return (
+    <label>
+      <input
+        type="checkbox"
+        checked={task.done}
+        onChange={handleChangeCheckbox}
+      />
+      {taskContent}
+      <button onClick={handleDeleteTask}>Delete</button>
+    </label>
+  );
+};

--- a/react-advanced/src/TaskApp/taskList.jsx
+++ b/react-advanced/src/TaskApp/taskList.jsx
@@ -1,8 +1,8 @@
-import { useContext, useState } from "react";
-import { TaskContext, TaskDispatchContext } from "./taskContext";
+import { useState } from "react";
+import { useTasks, useTasksDispatch } from "./taskContext";
 
 export const TaskList = () => {
-  const tasks = useContext(TaskContext);
+  const tasks = useTasks();
   return (
     <ul>
       {tasks.map((task) => (
@@ -16,7 +16,7 @@ export const TaskList = () => {
 
 const Task = ({ task }) => {
   const [isEditing, setIsEditing] = useState(false);
-  const dispatch = useContext(TaskDispatchContext);
+  const dispatch = useTasksDispatch();
   let taskContent;
 
   const handleCloseEditing = () => {


### PR DESCRIPTION
1. How to combine a reducer with context?

- You can combine a reducer with context by using the **useReducer** hook along with **createContext** in React.
- Use the useReducer hook to create state and dispatch from the reducer, then provide them through the context's value.

2. How to avoid passing state and dispatch through props?
- By using context and a reducer, you can avoid passing state and dispatch through props from a parent component to deeply nested child components.
3. How to keep context and state logic in a separate file?
- To keep context and state logic in a separate file, create a file containing the context and reducer, and then import it into the components that need to use them.
- This helps enhance reusability and maintainability of the codebase.