### PR TITLE
Implement referencing values with refs #155

### DIFF
--- a/react-advanced/src/App.js
+++ b/react-advanced/src/App.js
@@ -15,6 +15,7 @@ import { Messenger } from "./useReducer/messenger";
 import { ImageList } from "./useContext/imageList";
 import { TaskApp } from "./TaskApp";
 import { Stopwatch } from "./useRef/stopwatch";
+import { Chat } from "./useRef/inputChat";
 
 const App = () => {
   return (
@@ -91,7 +92,15 @@ const App = () => {
         <Route path="/extractingLogicState" element={<Messenger />} />
         <Route path="/passingDataWithContext" element={<ImageList />} />
         <Route path="/combiningReducerWithContext" element={<TaskApp />} />
-        <Route path="/referencingValuesWithRefs" element={<Stopwatch />} />
+        <Route
+          path="/referencingValuesWithRefs"
+          element={
+            <>
+              <Stopwatch />
+              <Chat/>
+            </>
+          }
+        />
       </Routes>
     </Router>
   );

--- a/react-advanced/src/App.js
+++ b/react-advanced/src/App.js
@@ -14,6 +14,7 @@ import { ContactList } from "./useState/preserving-resetting/contactList";
 import { Messenger } from "./useReducer/messenger";
 import { ImageList } from "./useContext/imageList";
 import { TaskApp } from "./TaskApp";
+import { Stopwatch } from "./useRef/stopwatch";
 
 const App = () => {
   return (
@@ -43,6 +44,11 @@ const App = () => {
           <li>
             <Link to="/combiningReducerWithContext">
               Combining Reducer with Context
+            </Link>
+          </li>
+          <li>
+            <Link to="/referencingValuesWithRefs">
+              Referencing Values with Refs
             </Link>
           </li>
         </ul>
@@ -85,6 +91,7 @@ const App = () => {
         <Route path="/extractingLogicState" element={<Messenger />} />
         <Route path="/passingDataWithContext" element={<ImageList />} />
         <Route path="/combiningReducerWithContext" element={<TaskApp />} />
+        <Route path="/referencingValuesWithRefs" element={<Stopwatch />} />
       </Routes>
     </Router>
   );

--- a/react-advanced/src/useRef/inputChat.jsx
+++ b/react-advanced/src/useRef/inputChat.jsx
@@ -3,18 +3,20 @@ import { useRef, useState } from "react";
 export const Chat = () => {
   const [isSending, setIsSending] = useState(false);
   const [text, setText] = useState("");
+
   const timeoutRef = useRef(null);
+  const textRef = useRef(null);
 
   const handleSend = () => {
     setIsSending(true);
     timeoutRef.current = setTimeout(() => {
-      alert("Sent!");
-      setIsSending(false);
-    }, 1000);
+      alert("Sending: " + textRef.current);
+    }, 3000);
   };
 
   const handleChange = (e) => {
     setText(e.target.value);
+    textRef.current = e.target.value;
   };
 
   const handleUndo = () => {
@@ -26,15 +28,10 @@ export const Chat = () => {
     <>
       <h1>Chat</h1>
       <input
-        disabled={isSending}
         value={text}
         onChange={handleChange}
       />
-      <button
-        disabled={isSending}
-        onClick={handleSend}>
-        {isSending ? "Sending..." : "Send"}
-      </button>
+      <button onClick={handleSend}>Send</button>
       {isSending &&
         <button onClick={handleUndo}>Undo</button>
       }

--- a/react-advanced/src/useRef/inputChat.jsx
+++ b/react-advanced/src/useRef/inputChat.jsx
@@ -1,0 +1,43 @@
+import { useRef, useState } from "react";
+
+export const Chat = () => {
+  const [isSending, setIsSending] = useState(false);
+  const [text, setText] = useState("");
+  const timeoutRef = useRef(null);
+
+  const handleSend = () => {
+    setIsSending(true);
+    timeoutRef.current = setTimeout(() => {
+      alert("Sent!");
+      setIsSending(false);
+    }, 1000);
+  };
+
+  const handleChange = (e) => {
+    setText(e.target.value);
+  };
+
+  const handleUndo = () => {
+    setIsSending(false);
+    clearTimeout(timeoutRef.current);
+  };
+
+  return (
+    <>
+      <h1>Chat</h1>
+      <input
+        disabled={isSending}
+        value={text}
+        onChange={handleChange}
+      />
+      <button
+        disabled={isSending}
+        onClick={handleSend}>
+        {isSending ? "Sending..." : "Send"}
+      </button>
+      {isSending &&
+        <button onClick={handleUndo}>Undo</button>
+      }
+    </>
+  );
+};

--- a/react-advanced/src/useRef/stopwatch.jsx
+++ b/react-advanced/src/useRef/stopwatch.jsx
@@ -1,0 +1,34 @@
+import { useRef, useState } from "react";
+
+export const Stopwatch = () => {
+  const [startTime, setStartTime] = useState(null);
+  const [now, setNow] = useState(null);
+  const intervalRef = useRef(null);
+
+  const handleStart = () => {
+    setStartTime(Date.now());
+    setNow(Date.now());
+
+    clearInterval(intervalRef.current);
+    intervalRef.current = setInterval(() => {
+      setNow(Date.now());
+    }, 10);
+  };
+
+  const handleStop = () => {
+    clearInterval(intervalRef.current);
+  };
+
+  let secondsPassed = 0;
+  if (startTime !== null && now !== null) {
+    secondsPassed = (now - startTime) / 1000;
+  }
+
+  return (
+    <>
+      <h1>Time passed: {secondsPassed.toFixed(3)}</h1>
+      <button onClick={handleStart}>Start</button>
+      <button onClick={handleStop}>Stop</button>
+    </>
+  );
+};


### PR DESCRIPTION
1. How to add a ref to your component?
- To add a ref to your component in React, you can use _**useRef**_.
2. How to update a ref’s value?
- Refs should not be updated directly. Instead, you can use the current property of the ref to change its value.
3. How refs are different from state?
- Refs and state are both ways to store and track information, but they serve different purposes. 
- Refs are often used to access DOM elements or to track values that don't cause a re-render. 
- In contrast, state is used to store values that can change and trigger a re-render when they do.
4. How to use refs safely?
- When using refs, ensure that you use them safely and avoid updating them directly. 
- Typically, refs are used to reference DOM elements, and instead of changing the value directly, you should use setState to update the state and trigger a re-render.
- Use refs cautiously to avoid conflicts with how React manages and updates state.