### PR TITLE
Implement manipulating dom with refs #156

### DIFF
--- a/react-advanced/src/App.css
+++ b/react-advanced/src/App.css
@@ -25,7 +25,8 @@
   background: #d2eaff;
 }
 
-textarea, label {
+textarea,
+label {
   display: block;
   margin: 10px 0;
 }
@@ -38,4 +39,22 @@ li {
 .contact-list {
   float: left;
   margin-right: 20px;
+}
+
+.navbar {
+  text-align: center;
+}
+
+.cat-container {
+  width: 100%;
+  overflow: hidden;
+}
+
+.list-cat {
+  white-space: nowrap;
+}
+
+.item-cat {
+  display: inline;
+  padding: 0.5rem;
 }

--- a/react-advanced/src/App.css
+++ b/react-advanced/src/App.css
@@ -51,10 +51,16 @@ li {
 }
 
 .list-cat {
+  display: flex;
   white-space: nowrap;
+  padding: 0.5rem;
 }
 
-.item-cat {
-  display: inline;
-  padding: 0.5rem;
+.cat-img {
+  padding: 10px;
+  transition: background 0.2s linear;
+}
+
+.active {
+  background: rgba(0, 100, 150, 0.4);
 }

--- a/react-advanced/src/App.js
+++ b/react-advanced/src/App.js
@@ -16,6 +16,7 @@ import { ImageList } from "./useContext/imageList";
 import { TaskApp } from "./TaskApp";
 import { Stopwatch } from "./useRef/stopwatch";
 import { Chat } from "./useRef/inputChat";
+import { CatFriends } from "./useRef/dom-with-ref/scrollImg";
 
 const App = () => {
   return (
@@ -50,6 +51,11 @@ const App = () => {
           <li>
             <Link to="/referencingValuesWithRefs">
               Referencing Values with Refs
+            </Link>
+          </li>
+          <li>
+            <Link to="/manipulatingDOMWithRefs">
+              Manipulating the DOM with Refs
             </Link>
           </li>
         </ul>
@@ -97,7 +103,15 @@ const App = () => {
           element={
             <>
               <Stopwatch />
-              <Chat/>
+              <Chat />
+            </>
+          }
+        />
+        <Route
+          path="/manipulatingDOMWithRefs"
+          element={
+            <>
+              <CatFriends />
             </>
           }
         />

--- a/react-advanced/src/App.js
+++ b/react-advanced/src/App.js
@@ -17,6 +17,7 @@ import { TaskApp } from "./TaskApp";
 import { Stopwatch } from "./useRef/stopwatch";
 import { Chat } from "./useRef/inputChat";
 import { CatFriends } from "./useRef/dom-with-ref/scrollImg";
+import { SearchPage } from "./useRef/dom-with-ref/focusInput";
 
 const App = () => {
   return (
@@ -112,6 +113,7 @@ const App = () => {
           element={
             <>
               <CatFriends />
+              <SearchPage />
             </>
           }
         />

--- a/react-advanced/src/useRef/dom-with-ref/focusInput.jsx
+++ b/react-advanced/src/useRef/dom-with-ref/focusInput.jsx
@@ -1,0 +1,24 @@
+import { forwardRef, useRef } from "react";
+
+const SearchButton = ({ onClick }) => (
+  <button onClick={onClick}>Search</button>
+)
+
+const SearchInput = forwardRef((_, ref) => (
+  <input ref={ref} placeholder="Looking for something" />
+));
+
+export const SearchPage = () => {
+  const inputRef = useRef(null);
+
+  const handleClick = () => {
+    inputRef.current.focus();
+  };
+
+  return (
+    <>
+      <SearchInput ref={inputRef} />
+      <SearchButton onClick={handleClick} />
+    </>
+  );
+};

--- a/react-advanced/src/useRef/dom-with-ref/scrollImg.jsx
+++ b/react-advanced/src/useRef/dom-with-ref/scrollImg.jsx
@@ -1,28 +1,20 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
+import { flushSync } from "react-dom";
 
 export const CatFriends = () => {
-  const firstCatRef = useRef(null);
-  const secondCatRef = useRef(null);
-  const thirdCatRef = useRef(null);
+  const selectedRef = useRef(null);
+  const [index, setIndex] = useState(0);
 
-  const handleScrollToFirstCat = () => {
-    firstCatRef.current.scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-      inline: "center",
+  const handleScrollCat = () => {
+    flushSync(() => {
+      if (index < catList.length - 1) {
+        setIndex(index + 1);
+      } else {
+        setIndex(0);
+      }
     });
-  };
 
-  const handleScrollToSecondCat = () => {
-    secondCatRef.current.scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-      inline: "center",
-    });
-  };
-
-  const handleScrollToThirdCat = () => {
-    thirdCatRef.current.scrollIntoView({
+    selectedRef.current.scrollIntoView({
       behavior: "smooth",
       block: "nearest",
       inline: "center",
@@ -32,35 +24,32 @@ export const CatFriends = () => {
   return (
     <>
       <nav className="navbar">
-        <button onClick={handleScrollToFirstCat}>Tom</button>
-        <button onClick={handleScrollToSecondCat}>Maru</button>
-        <button onClick={handleScrollToThirdCat}>Jellylorum</button>
+        <button onClick={handleScrollCat}>Next</button>
       </nav>
       <div className="cat-container">
         <ul className="list-cat">
-          <li className="item-cat">
-            <img
-              src="https://placekitten.com/g/200/200"
-              alt="Tom"
-              ref={firstCatRef}
-            />
-          </li>
-          <li className="item-cat">
-            <img
-              src="https://placekitten.com/g/300/200"
-              alt="Maru"
-              ref={secondCatRef}
-            />
-          </li>
-          <li className="item-cat">
-            <img
-              src="https://placekitten.com/g/250/200"
-              alt="Jellylorum"
-              ref={thirdCatRef}
-            />
-          </li>
+          {catList.map((cat, i) => (
+            <li
+              key={cat.id}
+              ref={index === i ? selectedRef : null}
+            >
+              <img
+                className={`cat-img ${index === i ? "active" : ""}`}
+                src={cat.imageUrl}
+                alt={"Cat #" + cat.id}
+              />
+            </li>
+          ))}
         </ul>
       </div>
     </>
   );
 };
+
+const catList = [];
+for (let i = 0; i < 10; i++) {
+  catList.push({
+    id: i,
+    imageUrl: "https://placekitten.com/250/200?image=" + i,
+  });
+}

--- a/react-advanced/src/useRef/dom-with-ref/scrollImg.jsx
+++ b/react-advanced/src/useRef/dom-with-ref/scrollImg.jsx
@@ -1,0 +1,66 @@
+import { useRef } from "react";
+
+export const CatFriends = () => {
+  const firstCatRef = useRef(null);
+  const secondCatRef = useRef(null);
+  const thirdCatRef = useRef(null);
+
+  const handleScrollToFirstCat = () => {
+    firstCatRef.current.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+  };
+
+  const handleScrollToSecondCat = () => {
+    secondCatRef.current.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+  };
+
+  const handleScrollToThirdCat = () => {
+    thirdCatRef.current.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+  };
+
+  return (
+    <>
+      <nav className="navbar">
+        <button onClick={handleScrollToFirstCat}>Tom</button>
+        <button onClick={handleScrollToSecondCat}>Maru</button>
+        <button onClick={handleScrollToThirdCat}>Jellylorum</button>
+      </nav>
+      <div className="cat-container">
+        <ul className="list-cat">
+          <li className="item-cat">
+            <img
+              src="https://placekitten.com/g/200/200"
+              alt="Tom"
+              ref={firstCatRef}
+            />
+          </li>
+          <li className="item-cat">
+            <img
+              src="https://placekitten.com/g/300/200"
+              alt="Maru"
+              ref={secondCatRef}
+            />
+          </li>
+          <li className="item-cat">
+            <img
+              src="https://placekitten.com/g/250/200"
+              alt="Jellylorum"
+              ref={thirdCatRef}
+            />
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
1. How to access a DOM node managed by React with the ref attribute
- In React, you can use the ref attribute to create a reference to a React element or component. 
- This allows you to directly access and manipulate the DOM node associated with that element or component.
2. How the ref JSX attribute relates to the useRef Hook
- The ref JSX attribute and the useRef Hook are related concepts in React.
- In class components, you use the ref attribute to create a reference and later access the DOM node.
3. How to access another component’s DOM node
- To access another component's DOM node, you can use a callback function with the ref attribute.
4. In which cases it’s safe to modify the DOM managed by React
- Avoid direct DOM manipulation outside of React's control in the initial render (render method), as it can lead to unexpected behavior.
- It's recommended to use React's state and props to manage the component's behavior, and only access the DOM directly when necessary.